### PR TITLE
removed unneeded header files

### DIFF
--- a/Hx_PlateReverb/effect_platervbstereo.cpp
+++ b/Hx_PlateReverb/effect_platervbstereo.cpp
@@ -31,8 +31,6 @@
 
 #include <Arduino.h>
 #include "effect_platervbstereo.h"
-#include "utility/dspinst.h"
-#include "synth_waveform.h"
 
 #define INP_ALLP_COEFF      (0.65f)
 #define LOOP_ALLOP_COEFF    (0.65f)


### PR DESCRIPTION
I'm playing around with your reverb in a custom build system where I included only what's needed from the Audio library.

It looks like these two header files are not needed for this effect/file. I would really appreciate if you could remove them so I can keep synchronized with your github repo.